### PR TITLE
Fix issue REC-31:Validator must be manual testes in xUnit

### DIFF
--- a/RecipeApi.Tests/RecipeApi.Tests.csproj
+++ b/RecipeApi.Tests/RecipeApi.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />


### PR DESCRIPTION
I did't change anything. I think that good idea is to use httpRequest in test rather than call functions of controllers. It will be real test for future client requests.

WebApplicationFactory<Startup> _factory = new...;

var client = _factory.CreateClient();

var token = "your_generated_jwt_token";
client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);

var response = await client.DeleteAsync("/api/ingredient/123");

response.EnsureSuccessStatusCode();
Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);